### PR TITLE
Set expected download path in headless mode

### DIFF
--- a/carbonsh/carbonsh.py
+++ b/carbonsh/carbonsh.py
@@ -28,6 +28,7 @@ async def url_to_file(url: str, location: str, extension='png', headless=False, 
 
         await export_container.screenshot({
             'path': str(location.joinpath('')),
+            'type': extension,
             'clip': {
                 **element_bounds,
                 'x': round(element_bounds['x']),

--- a/carbonsh/carbonsh.py
+++ b/carbonsh/carbonsh.py
@@ -27,7 +27,7 @@ async def url_to_file(url: str, location: str, extension='png', headless=False, 
         element_bounds = await export_container.boundingBox()
 
         await export_container.screenshot({
-            'path': str(location.joinpath('carbon.png')),
+            'path': str(location.joinpath('')),
             'clip': {
                 **element_bounds,
                 'x': round(element_bounds['x']),

--- a/tests/test_carbonsh.py
+++ b/tests/test_carbonsh.py
@@ -52,10 +52,10 @@ class TestPng(TestCase):
     def test_url_to_file_headless(self):
         url = code_to_url('const test = "testing headless"', Config())
         temp = tempfile.TemporaryDirectory()
-        temp_path = Path(temp.name).joinpath('')
+        temp_path = Path(temp.name).joinpath('carbon.png')
         loop = asyncio.get_event_loop()
         loop.run_until_complete(url_to_file(url, temp_path, headless=True))
-        self.assertTrue(isfile(temp_path.joinpath('carbon.png')))
+        self.assertTrue(isfile(temp_path))
         temp.cleanup()
 
 


### PR DESCRIPTION
In headless mode, "carbon.png" gets appended to the download path. If not in headless, you can control the exact path.
Make the headless mode behave the same way.