### PR TITLE
Accept "rgba()" background color definitions

### DIFF
--- a/carbonsh/Config.py
+++ b/carbonsh/Config.py
@@ -9,6 +9,7 @@ def parse_bg(background) -> str:
         return 'rgba(171, 184, 195, 1)'
     elif background[0] == '#' or '(' not in background:
         return f'rgba{hex_to_rgb(background) + (1,)}'
+    return background
 
 
 def int_to_px(number) -> str:


### PR DESCRIPTION
In the current situation, if we provide a rgba() background color, it will be cast as "None" in the URL since it is not returned in the function.